### PR TITLE
GitHub flavored MarkDown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Capabilities
 
 A Haskell library providing separation of effects on the type level, effectively splitting up the monolithic IO-monad into more limited capabilities.
 
-* Install:
+* Install Library:
 ```
 cd Capabilities
 cabal install
-'''
+```
 
-* Doc
+* Extract Documentation
 ```
 runhaskell Setup.hs haddock --hoogle
-'''
+```


### PR DESCRIPTION
Distinguish between code and headings to improve human readability of instructions.